### PR TITLE
build!: release posts the release tag and points :latest to it

### DIFF
--- a/.github/workflows/CD-docker_release.yml
+++ b/.github/workflows/CD-docker_release.yml
@@ -31,4 +31,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ vars.DOCKERHUB_REPO }}/${{ vars.DOCKERHUB_IMG }}:${{ github.event.release.tag_name }}
+          tags: |
+            ${{ vars.DOCKERHUB_REPO }}/${{ vars.DOCKERHUB_IMG }}:${{ github.event.release.tag_name }}
+            ${{ vars.DOCKERHUB_REPO }}/${{ vars.DOCKERHUB_IMG }}:latest


### PR DESCRIPTION
It currently doesn't do :latest tag. It only releases per version. We're currently pointing to :dev for most of our use. That's very outdated now. See https://hub.docker.com/r/runpod/mock-worker/tags